### PR TITLE
Fix Firebase configuration and ChatService bugs

### DIFF
--- a/ChatService.js
+++ b/ChatService.js
@@ -202,6 +202,7 @@ class ChatService {
 
   // Listen to chat messages in real-time
   subscribeToChatMessages(chatId, callback) {
+    const db = getFirebaseDB();
     const messagesRef = collection(db, 'chats', chatId, 'messages');
     const q = query(messagesRef, orderBy('timestamp', 'asc'));
     
@@ -216,6 +217,7 @@ class ChatService {
 
   // Listen to user's chats in real-time
   subscribeToUserChats(userId, callback) {
+    const db = getFirebaseDB();
     const chatsRef = collection(db, 'chats');
     const q = query(
       chatsRef,
@@ -257,6 +259,7 @@ class ChatService {
   // Mark messages as read
   async markMessagesAsRead(chatId, userId) {
     try {
+      const db = getFirebaseDB();
       const messagesRef = collection(db, 'chats', chatId, 'messages');
       const q = query(
         messagesRef,
@@ -279,6 +282,7 @@ class ChatService {
   // Delete a message
   async deleteMessage(chatId, messageId) {
     try {
+      const db = getFirebaseDB();
       await deleteDoc(doc(db, 'chats', chatId, 'messages', messageId));
     } catch (error) {
       console.error('Error deleting message:', error);
@@ -289,10 +293,11 @@ class ChatService {
   // Leave a group chat
   async leaveGroupChat(chatId, userId) {
     try {
+      const db = getFirebaseDB();
       await updateDoc(doc(db, 'chats', chatId), {
         participants: arrayRemove(userId)
       });
-      
+
       await updateDoc(doc(db, 'users', userId), {
         chats: arrayRemove(chatId)
       });

--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -9,7 +9,7 @@ const firebaseConfig = {
   apiKey: "AIzaSyAkWfYFDm84s3bz_aUAUAfUDmxxjg7DNnw",
   authDomain: "lodugram.firebaseapp.com",
   projectId: "lodugram",
-  storageBucket: "lodugram.firebasestorage.app",
+  storageBucket: "lodugram.appspot.com",
   messagingSenderId: "506675227207",
   appId: "1:506675227207:web:162dee371450d6cdccdf62"
 };


### PR DESCRIPTION
## Summary
- correct Firebase storage bucket URL
- fix ChatService to obtain `db` instance in real-time methods

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886ab61285483229119dac98ac7d87f