### PR TITLE
Fix runtime error by registering auth component alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import { registerRootComponent } from 'expo';
+import { AppRegistry } from 'react-native';
 
 import App from './App';
 
@@ -6,3 +7,8 @@ import App from './App';
 // It also ensures that whether you load the app in Expo Go or in a native build,
 // the environment is set up appropriately
 registerRootComponent(App);
+
+// Some build configurations attempt to start the app using the component name
+// "auth" instead of the default "main". Registering this alias avoids runtime
+// errors like "Component auth has not been registered yet".
+AppRegistry.registerComponent('auth', () => App);


### PR DESCRIPTION
## Summary
- register `auth` component alias in `index.js` to avoid "Component auth has not been registered" runtime crash

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886ae76e96c8322a4cbcb9780ba5427