### PR TITLE
Improve chat functionality

### DIFF
--- a/ChatService.js
+++ b/ChatService.js
@@ -84,13 +84,14 @@ class ChatService {
   }
 
   // Create a group chat
-  async createGroupChat(name, participants, createdBy) {
+  async createGroupChat(name, participants, createdBy, description = '') {
     try {
       const db = getFirebaseDB();
       const groupRef = await addDoc(collection(db, 'chats'), {
-        name: name,
-        participants: participants,
-        createdBy: createdBy,
+        name,
+        description,
+        participants,
+        createdBy,
         isGroup: true,
         lastMessage: null,
         lastMessageTime: null,

--- a/Screens/ChatScreen.js
+++ b/Screens/ChatScreen.js
@@ -25,40 +25,32 @@ const ChatScreen = ({ navigation }) => {
   const [sending, setSending] = useState(false);
 
   useEffect(() => {
-    if (user) {
-      loadChats();
-    }
+    if (!user) return;
+
+    setLoading(true);
+    const unsubscribe = ChatService.subscribeToUserChats(user.uid, (c) => {
+      setChats(c);
+      setLoading(false);
+    });
+
+    return unsubscribe;
   }, [user]);
 
   useEffect(() => {
-    if (selectedChat) {
-      loadMessages(selectedChat.id);
-      markMessagesAsRead(selectedChat.id);
-    }
+    if (!selectedChat) return;
+
+    setMessages([]);
+    const unsubscribe = ChatService.subscribeToChatMessages(
+      selectedChat.id,
+      setMessages
+    );
+
+    markMessagesAsRead(selectedChat.id);
+
+    return unsubscribe;
   }, [selectedChat]);
 
-  const loadChats = async () => {
-    try {
-      setLoading(true);
-      const userChats = await ChatService.getUserChats(user.uid);
-      setChats(userChats);
-    } catch (error) {
-      console.error('Error loading chats:', error);
-      Alert.alert('Error', 'Failed to load chats');
-    } finally {
-      setLoading(false);
-    }
-  };
 
-  const loadMessages = async (chatId) => {
-    try {
-      const chatMessages = await ChatService.getChatMessages(chatId);
-      setMessages(chatMessages);
-    } catch (error) {
-      console.error('Error loading messages:', error);
-      Alert.alert('Error', 'Failed to load messages');
-    }
-  };
 
   const markMessagesAsRead = async (chatId) => {
     try {

--- a/Screens/CreateGroupScreen.js
+++ b/Screens/CreateGroupScreen.js
@@ -72,7 +72,12 @@ const CreateGroupScreen = ({ navigation }) => {
     try {
       // Include current user in participants
       const participants = [user.uid, ...selectedUsers];
-      await ChatService.createGroupChat(groupName, participants, user.uid);
+      await ChatService.createGroupChat(
+        groupName,
+        participants,
+        user.uid,
+        description
+      );
       
       Alert.alert('Success', 'Group created successfully!', [
         { text: 'OK', onPress: () => navigation.goBack() }

--- a/Screens/UsernameScreen.js
+++ b/Screens/UsernameScreen.js
@@ -14,7 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { BlurView } from 'expo-blur';
 
 const UsernameScreen = ({ navigation }) => {
-  const { user, setUserUsername } = useAuth();
+  const { setUserUsername } = useAuth();
   const [username, setUsername] = useState('');
   const [loading, setLoading] = useState(false);
 


### PR DESCRIPTION
## Summary
- switch chat screen to realtime Firestore subscriptions
- store description when creating a group chat
- remove unused `user` variable in username screen

## Testing
- `node -c ChatService.js`
- `node -c Screens/ChatScreen.js`
- `node -c Screens/CreateGroupScreen.js`
- `node -c Screens/UsernameScreen.js`


------
https://chatgpt.com/codex/tasks/task_e_6886b06718ec83229f282b376139a89a